### PR TITLE
Implementado filtro integration_rede_installments para dar mais opçõe…

### DIFF
--- a/includes/class-wc-rede-credit.php
+++ b/includes/class-wc-rede-credit.php
@@ -337,8 +337,16 @@ class WC_Rede_Credit extends WC_Rede_Abstract {
 
 	public function get_installments( $order_total = 0 ) {
 		$installments = [];
-		$min_value = $this->min_parcels_value;
-		$max_parcels = $this->max_parcels_number;
+
+        $defaults = array(
+            'min_value' => $this->min_parcels_value,
+            'max_parcels' => $this->max_parcels_number,
+        );
+
+        $installments_result = wp_parse_args(apply_filters('integration_rede_installments', $defaults), $defaults);
+
+        $min_value = $installments_result['min_value'];
+        $max_parcels = $installments_result['max_parcels'];
 
 		for ( $i = 1; $i <= $max_parcels; ++$i ) {
 			if ( ( $order_total / $i ) >= $min_value ) {


### PR DESCRIPTION
Implementei uma chamada de filtro no uso de valor mínimo e parcelas assim da mais opções para quem for utilizar o plugin na hora de avaliar estes dados, por exemplo analisando os itens do pedido ou mesmo dados do usuário logado.

Caso não seja usado o filtro ele segue os valores da configuração.

Por exemplo:

```
function alk_teste_cartao_filter($installments)
{
    $installments['min_value'] = 40;
    $installments['max_parcels'] = 3;
    return $installments;
}

add_filter('integration_rede_installments', 'alk_teste_cartao_filter');

```